### PR TITLE
Fixed link to Smartweather Example.md

### DIFF
--- a/Weather Sensors.md
+++ b/Weather Sensors.md
@@ -36,5 +36,6 @@ You'll also need to register for an `api_key`.
 
 Of course there is *no requirement* to use Smartweather for rainfall data but if you use something else you will need to change the Lovelace to fit and also the code that collects rainfall measurements.
 
-There are some pointers for setting SmartWeather up [here](https://github.com/kloggy/HA-Irrigation-Version2/blob/master/smartweather_example.md).
+There are some pointers for setting SmartWeather up [here](https://github.com/kloggy/HA-Irrigation-Version2/blob/master/Smartweather%20Example.md).
 
+Of course there is *no requirement* to use Smartweather for rainfall data but if you use something else you will need to change the Lovelace to fit and also the code that collects rainfall measurements.


### PR DESCRIPTION
The previous link leaded to a 404 because of wrong filename.