### PR TITLE
new MQTT key

### DIFF
--- a/Garden Irrigation/irrigation_remote_control.yaml
+++ b/Garden Irrigation/irrigation_remote_control.yaml
@@ -2,13 +2,12 @@
 #============
 #=== Sensors
 #============
-sensor:
-
+mqtt:
+  sensor:
   # Irrigation Remote Control
-  - platform: mqtt
-    name: Irrigation Remote Control
-    state_topic: "433/Irrigation_Remote_Control"
-    expire_after: 2
+    - name: Irrigation Remote Control
+      state_topic: "433/Irrigation_Remote_Control"
+      expire_after: 2
 
 
 #===================


### PR DESCRIPTION
2022.6.0 will introduce a seperate MQTT key instead of defining manually configured MQTT entities directly under the sensor platform key