### PR TITLE
Modernize package to current HA (2026) syntax + robustness

### DIFF
--- a/Garden Irrigation/irrigation_cancel.yaml
+++ b/Garden Irrigation/irrigation_cancel.yaml
@@ -13,8 +13,8 @@ script:
   irrigation_cancel_irrigation:
     alias: Irrigation Cancel Irrigation
     sequence:
-      - service: input_boolean.turn_off
-        data_template:
+      - action: input_boolean.turn_off
+        data:
           entity_id: >
             input_boolean.irrigation_{{ cycle }}_running
 
@@ -22,8 +22,8 @@ script:
       #====================
       #=== TURN VALVES OFF
       #====================
-      - service: switch.turn_off
-        data_template:
+      - action: switch.turn_off
+        data:
           entity_id: > 
             {% for switch_name in states.input_text if switch_name.object_id.startswith('irrigation_zone') and
                                                       switch_name.object_id.endswith('switch_entity_id') -%}
@@ -41,14 +41,14 @@ script:
       #=== UPDATE SOME HEADINGS
       #=========================
       #=== Update Status to Idle
-      - service: input_text.set_value
+      - action: input_text.set_value
         data:
           entity_id: input_text.irrigation_current_status
           value: SYSTEM IDLE
 
       #=== Update previous cycle name to show cycle cancelled
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_previous_run_cycle_name
           value: >
             {{ states('input_text.irrigation_previous_run_cycle_name') ~ ' (Cancelled)' }}
@@ -65,8 +65,8 @@ script:
           {{ zone != 'none' }}
 
       #=== Pause zone timer to get time elapsed
-      - service: timer.pause
-        data_template:
+      - action: timer.pause
+        data:
           entity_id: >
             timer.irrigation_{{ zone }}_timer
 
@@ -75,8 +75,8 @@ script:
       #=== SET DETAILS OF LAST RUN
       #============================
       #=== Update last run time for this zone
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: >
             input_text.irrigation_{{ zone }}_previous_duration_in_seconds
           value: >
@@ -89,8 +89,8 @@ script:
             {{ (original_duration - duration_remaining_secs) | string }}
 
       #=== Update last run total watering time
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_previous_total_watering_time
           value: >
             {% set original_duration = states('sensor.irrigation_' ~ cycle ~ '_' ~ zone ~ '_actual_duration_in_seconds') | float %}
@@ -106,8 +106,8 @@ script:
       #=====================
       #=== CANCEL THE TIMER
       #=====================
-      - service: timer.cancel
-        data_template:
+      - action: timer.cancel
+        data:
           entity_id: >
             timer.irrigation_{{ zone }}_timer
 
@@ -115,5 +115,5 @@ script:
       #====================
       #=== STOP THE SCRIPT
       #====================
-      - service: script.turn_off
+      - action: script.turn_off
         entity_id: script.irrigation_run_a_cycle

--- a/Garden Irrigation/irrigation_controller.yaml
+++ b/Garden Irrigation/irrigation_controller.yaml
@@ -57,10 +57,10 @@ automation:
     id: irrigation_set_default_controller_wifi_1_signal_sensor
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_text.irrigation_external_sensor_controller_1_wifi
         to: ''
 
@@ -76,7 +76,7 @@ automation:
           state: ''
 
     action:
-      - service: input_text.set_value
+      - action: input_text.set_value
         data:
           entity_id: input_text.irrigation_external_sensor_controller_1_wifi
           value: Not set
@@ -90,10 +90,10 @@ automation:
     id: irrigation_set_default_controller_2_wifi_signal_sensor
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_text.irrigation_external_sensor_controller_2_wifi
         to: ''
 
@@ -109,7 +109,7 @@ automation:
           state: ''
 
     action:
-      - service: input_text.set_value
+      - action: input_text.set_value
         data:
           entity_id: input_text.irrigation_external_sensor_controller_2_wifi
           value: Not set

--- a/Garden Irrigation/irrigation_cycle_update_start_time.yaml
+++ b/Garden Irrigation/irrigation_cycle_update_start_time.yaml
@@ -15,18 +15,18 @@ automation:
   - alias: Irrigation Cycle1 Start Time Sunrise Offset
     id: irrigation_cycle1_start_time_sunrise_offset
     trigger:
-      - platform: state
+      - trigger: state
         entity_id: sun.sun
         attribute: next_rising
 
-      - platform: state
+      - trigger: state
         entity_id: input_select.irrigation_cycle1_start_time_type
         to: Sunrise Offset
 
-      - platform: state
+      - trigger: state
         entity_id: input_number.irrigation_cycle1_start_time_sunrise_offset
 
-      - platform: state
+      - trigger: state
         entity_id: input_boolean.irrigation_cycle1_running
         from: 'on'
         to: 'off'
@@ -37,9 +37,9 @@ automation:
         state: Sunrise Offset
 
     action:
-      - service: input_datetime.set_datetime
+      - action: input_datetime.set_datetime
         entity_id: input_datetime.irrigation_cycle1_start_time
-        data_template:
+        data:
           time: >
             {% set offset_secs = states('input_number.irrigation_cycle1_start_time_sunrise_offset') | int * 60 %}
             {% set start_time = as_timestamp(state_attr('sun.sun', 'next_rising')) | int + offset_secs %}
@@ -52,18 +52,18 @@ automation:
   - alias: Irrigation Cycle1 Start Time Sunset Offset
     id: irrigation_cycle1_start_time_sunset_offset
     trigger: 
-      - platform: state
+      - trigger: state
         entity_id: sun.sun
         attribute: next_setting
 
-      - platform: state
+      - trigger: state
         entity_id: input_select.irrigation_cycle1_start_time_type
         to: Sunset Offset
 
-      - platform: state
+      - trigger: state
         entity_id: input_number.irrigation_cycle1_start_time_sunset_offset
 
-      - platform: state
+      - trigger: state
         entity_id: input_boolean.irrigation_cycle1_running
         from: 'on'
         to: 'off'
@@ -74,9 +74,9 @@ automation:
         state: Sunset Offset
 
     action:
-      - service: input_datetime.set_datetime
+      - action: input_datetime.set_datetime
         entity_id: input_datetime.irrigation_cycle1_start_time
-        data_template:
+        data:
           time: >
             {% set offset_secs = states('input_number.irrigation_cycle1_start_time_sunset_offset') | int * 60 %}
             {% set start_time = as_timestamp(state_attr('sun.sun', 'next_setting')) | int + offset_secs %}
@@ -89,18 +89,18 @@ automation:
   - alias: Irrigation Cycle2 Start Time Sunrise Offset
     id: irrigation_cycle2_start_time_sunrise_offset
     trigger: 
-      - platform: state
+      - trigger: state
         entity_id: sun.sun
         attribute: next_rising
 
-      - platform: state
+      - trigger: state
         entity_id: input_select.irrigation_cycle2_start_time_type
         to: Sunrise Offset
 
-      - platform: state
+      - trigger: state
         entity_id: input_number.irrigation_cycle2_start_time_sunrise_offset
 
-      - platform: state
+      - trigger: state
         entity_id: input_boolean.irrigation_cycle2_running
         from: 'on'
         to: 'off'
@@ -111,9 +111,9 @@ automation:
         state: Sunrise Offset
 
     action:
-      - service: input_datetime.set_datetime
+      - action: input_datetime.set_datetime
         entity_id: input_datetime.irrigation_cycle2_start_time
-        data_template:
+        data:
           time: >
             {% set offset_secs = states('input_number.irrigation_cycle2_start_time_sunrise_offset') | int * 60 %}
             {% set start_time = as_timestamp(state_attr('sun.sun', 'next_rising')) | int + offset_secs %}
@@ -126,18 +126,18 @@ automation:
   - alias: Irrigation Cycle2 Start Time Sunset Offset
     id: irrigation_cycle2_start_time_sunset_offset
     trigger: 
-      - platform: state
+      - trigger: state
         entity_id: sun.sun
         attribute: next_setting
 
-      - platform: state
+      - trigger: state
         entity_id: input_select.irrigation_cycle2_start_time_type
         to: Sunset Offset
 
-      - platform: state
+      - trigger: state
         entity_id: input_number.irrigation_cycle2_start_time_sunset_offset
 
-      - platform: state
+      - trigger: state
         entity_id: input_boolean.irrigation_cycle2_running
         from: 'on'
         to: 'off'
@@ -148,9 +148,9 @@ automation:
         state: Sunset Offset
 
     action:
-      - service: input_datetime.set_datetime
+      - action: input_datetime.set_datetime
         entity_id: input_datetime.irrigation_cycle2_start_time
-        data_template:
+        data:
           time: >
             {% set offset_secs = states('input_number.irrigation_cycle2_start_time_sunset_offset') | int * 60 %}
             {% set start_time = as_timestamp(state_attr('sun.sun', 'next_setting')) | int + offset_secs %}

--- a/Garden Irrigation/irrigation_globals_groups.yaml
+++ b/Garden Irrigation/irrigation_globals_groups.yaml
@@ -20,10 +20,10 @@ automation:
     id: irrigation_create_groups
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: event
+      - trigger: event
         event_type: call_service
         event_data:
           domain: group
@@ -31,194 +31,118 @@ automation:
 
     action:
       #=== Cycle 1 all Zone Durations
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle1_zone_durations
-          entities: >
-            {%- for sensor in states.sensor if sensor.object_id.startswith('irrigation_cycle1_zone') and
-                                               sensor.object_id.endswith('_actual_duration_in_seconds') %}
-              {{ sensor.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.sensor | selectattr('object_id', 'match', 'irrigation_cycle1_zone.*_actual_duration_in_seconds$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 2 all Zone Durations
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle2_zone_durations
-          entities: >
-            {%- for sensor in states.sensor if sensor.object_id.startswith('irrigation_cycle2_zone') and
-                                               sensor.object_id.endswith('_actual_duration_in_seconds') %}
-              {{ sensor.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.sensor | selectattr('object_id', 'match', 'irrigation_cycle2_zone.*_actual_duration_in_seconds$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 3 all Zone Durations
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle3_zone_durations
-          entities: >
-            {%- for sensor in states.sensor if sensor.object_id.startswith('irrigation_cycle3_zone') and
-                                               sensor.object_id.endswith('_actual_duration_in_seconds') %}
-              {{ sensor.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.sensor | selectattr('object_id', 'match', 'irrigation_cycle3_zone.*_actual_duration_in_seconds$') | map(attribute='entity_id') | list }}"
 
 
       #=== Cycle 1 Zone Every Day
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle1_every_day
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle1_zone') and
-                                                       boolean.object_id.endswith('_every_day') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle1_zone.*_every_day$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 1 Zone Monday
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle1_mon
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle1_zone') and
-                                                       boolean.object_id.endswith('_mon') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle1_zone.*_mon$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 1 Zone Tuesday
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle1_tue
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle1_zone') and
-                                                       boolean.object_id.endswith('_tue') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle1_zone.*_tue$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 1 Zone Wednesday
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle1_wed
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle1_zone') and
-                                                       boolean.object_id.endswith('_wed') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle1_zone.*_wed$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 1 Zone Thursday
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle1_thu
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle1_zone') and
-                                                       boolean.object_id.endswith('_thu') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle1_zone.*_thu$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 1 Zone Friday
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle1_fri
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle1_zone') and
-                                                       boolean.object_id.endswith('_fri') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle1_zone.*_fri$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 1 Zone Saturday
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle1_sat
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle1_zone') and
-                                                       boolean.object_id.endswith('_sat') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle1_zone.*_sat$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 1 Zone Sunday
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle1_sun
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle1_zone') and
-                                                       boolean.object_id.endswith('_sun') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle1_zone.*_sun$') | map(attribute='entity_id') | list }}"
 
 
       #=== Cycle 2 Zone Every Day
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle2_every_day
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle2_zone') and
-                                                       boolean.object_id.endswith('_every_day') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle2_zone.*_every_day$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 2 Zone Monday
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle2_mon
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle2_zone') and
-                                                       boolean.object_id.endswith('_mon') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle2_zone.*_mon$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 2 Zone Tuesday
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle2_tue
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle2_zone') and
-                                                       boolean.object_id.endswith('_tue') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle2_zone.*_tue$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 2 Zone Wednesday
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle2_wed
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle2_zone') and
-                                                       boolean.object_id.endswith('_wed') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle2_zone.*_wed$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 2 Zone Thursday
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle2_thu
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle2_zone') and
-                                                       boolean.object_id.endswith('_thu') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle2_zone.*_thu$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 2 Zone Friday
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle2_fri
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle2_zone') and
-                                                       boolean.object_id.endswith('_fri') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle2_zone.*_fri$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 2 Zone Saturday
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle2_sat
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle2_zone') and
-                                                       boolean.object_id.endswith('_sat') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle2_zone.*_sat$') | map(attribute='entity_id') | list }}"
 
       #=== Cycle 2 Zone Sunday
-      - service: group.set
+      - action: group.set
         data:
           object_id: irrigation_group_cycle2_sun
-          entities: >
-            {%- for boolean in states.input_boolean if boolean.object_id.startswith('irrigation_cycle2_zone') and
-                                                       boolean.object_id.endswith('_sun') %}
-              {{ boolean.entity_id}}{% if not loop.last %}, {% endif %}
-            {%- endfor %}
+          entities: "{{ states.input_boolean | selectattr('object_id', 'match', 'irrigation_cycle2_zone.*_sun$') | map(attribute='entity_id') | list }}"
 

--- a/Garden Irrigation/irrigation_logging.yaml
+++ b/Garden Irrigation/irrigation_logging.yaml
@@ -28,7 +28,7 @@ script:
                 value_template: >
                   {{ log_event == 'CONTROLLER_UNAVAILABLE' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -40,7 +40,7 @@ script:
                 value_template: >
                   {{ log_event == 'CONTROLLER_AVAILABLE' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -53,7 +53,7 @@ script:
                 value_template: >
                   {{ log_event == 'SINGLE_ZONE_STARTING' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -66,7 +66,7 @@ script:
                 value_template: >
                   {{ log_event == 'FAILSAFE_SET' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -79,7 +79,7 @@ script:
                 value_template: >
                   {{ log_event == 'CYCLE_WAITING_FOR_ENTITY' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -97,7 +97,7 @@ script:
                 value_template: >
                   {{ log_event == 'CYCLE_WAITING_FOR_ENTITY_COMPLETE' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -113,7 +113,7 @@ script:
                 value_template: >
                   {{ log_event == 'CYCLE_ABORTED_WAITING_FOR_ENTITY' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -128,7 +128,7 @@ script:
                 value_template: >
                   {{ log_event == 'CYCLE_CONTINUES_UNEXPECTED_STATE' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -143,7 +143,7 @@ script:
                 value_template: >
                   {{ log_event == 'CYCLE_STARTING' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -156,7 +156,7 @@ script:
                 value_template: >
                   {{ log_event == 'CYCLE_ENDED' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -171,7 +171,7 @@ script:
                 value_template: >
                   {{ log_event == 'ZONE_STARTING' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -188,7 +188,7 @@ script:
                 value_template: >
                   {{ log_event == 'ZONE_WATERING' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -201,7 +201,7 @@ script:
                 value_template: >
                   {{ log_event == 'ZONE_STOPPING' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -209,7 +209,7 @@ script:
                     {{ event_time }} - Zone {{ zone }} ({{ zone_name }}) stopping
 
         default:
-          - service: notify.send_message
+          - action: notify.send_message
             entity_id: notify.log_irrigation
             data:
               message: >

--- a/Garden Irrigation/irrigation_logging_remote.yaml
+++ b/Garden Irrigation/irrigation_logging_remote.yaml
@@ -22,7 +22,7 @@ script:
                 value_template: >
                   {{ log_event == 'REMOTE_CANCEL' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -34,7 +34,7 @@ script:
                 value_template: >
                   {{ log_event == 'REMOTE_BUTTON_PRESS' }}
             sequence:
-              - service: notify.send_message
+              - action: notify.send_message
                 entity_id: notify.log_irrigation
                 data:
                   message: >
@@ -53,7 +53,7 @@ automation:
     id: irrigation_remote_event_irrigation_remote_cancel
     mode: queued
     trigger:
-      - platform: event
+      - trigger: event
         event_type: IRRIGATION_REMOTE_CANCEL
 
     condition:
@@ -62,7 +62,7 @@ automation:
         state: 'on'
 
     action:
-      - service: notify.send_message
+      - action: notify.send_message
         entity_id: notify.log_irrigation
         data:
           message: >
@@ -76,7 +76,7 @@ automation:
     id: irrigation_remote_event_irrigation_remote_button_press
     mode: queued
     trigger:
-      - platform: event
+      - trigger: event
         event_type: IRRIGATION_REMOTE_BUTTON_PRESS
 
     condition:
@@ -85,7 +85,7 @@ automation:
         state: 'on'
 
     action:
-      - service: notify.send_message
+      - action: notify.send_message
         entity_id: notify.log_irrigation
         data:
           message: >

--- a/Garden Irrigation/irrigation_master_control_and_failsafe.yaml
+++ b/Garden Irrigation/irrigation_master_control_and_failsafe.yaml
@@ -21,10 +21,10 @@ automation:
     id: irrigation_master_control_switch_on
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_boolean.irrigation_master_control_switch
         to: 'on'
 
@@ -35,8 +35,8 @@ automation:
     
     action:
       #=== Turn ON Automations
-      - service: automation.turn_on
-        data_template:
+      - action: automation.turn_on
+        data:
           entity_id: >
             {% for automation in states.automation if automation.object_id.startswith('irrigation') and
                                                       'irrigation_remote_control' not in automation.object_id %}
@@ -44,7 +44,7 @@ automation:
             {% endfor %}
 
       #===  Trigger Automations required for setting up globals
-      - service: automation.trigger
+      - action: automation.trigger
         entity_id: automation.irrigation_create_groups
 
 
@@ -55,10 +55,10 @@ automation:
     id: irrigation_master_control_switch_off
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_boolean.irrigation_master_control_switch
         to: 'off'
 
@@ -69,8 +69,8 @@ automation:
     
     action:
       #=== Turn OFF Automations
-      - service: automation.turn_off
-        data_template:
+      - action: automation.turn_off
+        data:
           entity_id: >
             {% for automation in states.automation if automation.object_id.startswith('irrigation') and
                                                       'irrigation_remote_control_switch' not in automation.object_id and
@@ -79,14 +79,14 @@ automation:
             {% endfor %}
 
       #=== Turn OFF all schedules
-      - service: input_boolean.turn_off
+      - action: input_boolean.turn_off
         entity_id:
           - input_boolean.irrigation_cycle1_schedule_enabled
           - input_boolean.irrigation_cycle2_schedule_enabled
 
       #=== Turn off all zone valves explicitly 
-      - service: switch.turn_off
-        data_template:
+      - action: switch.turn_off
+        data:
           entity_id: > 
             {% for switch_name in states.input_text if switch_name.object_id.startswith('irrigation_zone') and
                                                        switch_name.object_id.endswith('switch_entity_id') and
@@ -97,6 +97,6 @@ automation:
             {%- endfor %}
 
       #=== Turn OFF remote control
-      - service: input_boolean.turn_off
+      - action: input_boolean.turn_off
         entity_id:
           - input_boolean.irrigation_remote_control

--- a/Garden Irrigation/irrigation_notifications.yaml
+++ b/Garden Irrigation/irrigation_notifications.yaml
@@ -25,11 +25,11 @@ automation:
     id: irrigation_notify_when_controller_goes_offline
     mode: queued
     trigger:
-      - platform: state
+      - trigger: state
         entity_id: sensor.esphome_irrigation_controller_wifi_signal
         to: unavailable
 
-      - platform: state
+      - trigger: state
         entity_id: sensor.esphome_irrigation_controller_wifi_signal
         from: unavailable
 
@@ -39,8 +39,8 @@ automation:
         state: 'on'
 
     action:
-      - service: script.notify
-        data_template:
+      - action: script.notify
+        data:
           show: true
           notification_id: >
             notifications_{{ now() | string }}
@@ -60,11 +60,11 @@ automation:
   - alias: Irrigation Notify About Cycle WiFi Interruption
     id: irrigation_notify_about_cycle_wifi_interruption
     trigger:
-      - platform: state
+      - trigger: state
         entity_id: sensor.esphome_irrigation_controller_wifi_signal
         to: unavailable
 
-      - platform: state
+      - trigger: state
         entity_id: sensor.esphome_irrigation_controller_wifi_signal
         from: unavailable
 
@@ -117,8 +117,8 @@ automation:
           entity_id: input_boolean.irrigation_notify_user1
           state: 'on'
         then:
-          - service: script.notify
-            data_template:
+          - action: script.notify
+            data:
               tell: >
                 {{ states('input_text.notifications_user1_name') }}
               type: app_notification
@@ -131,8 +131,8 @@ automation:
           entity_id: input_boolean.irrigation_notify_user2
           state: 'on'
         then:
-          - service: script.notify
-            data_template:
+          - action: script.notify
+            data:
               tell: >
                 {{ states('input_text.notifications_user2_name') }}
               type: app_notification
@@ -147,11 +147,11 @@ automation:
   - alias: Irrigation Notify When Cycle Starts Or Stops
     id: irrigation_notify_when_cycle_starts_or_stops
     trigger:
-      - platform: state
+      - trigger: state
         entity_id: input_boolean.irrigation_cycle1_running
         id: cycle1
 
-      - platform: state
+      - trigger: state
         entity_id: input_boolean.irrigation_cycle2_running
         id: cycle2
 
@@ -203,8 +203,8 @@ automation:
           entity_id: input_boolean.irrigation_notify_user1
           state: 'on'
         then:
-          - service: script.notify
-            data_template:
+          - action: script.notify
+            data:
               tell: >
                 {{ states('input_text.notifications_user1_name') | lower }}
               type: app_notification
@@ -217,8 +217,8 @@ automation:
           entity_id: input_boolean.irrigation_notify_user2
           state: 'on'
         then:
-          - service: script.notify
-            data_template:
+          - action: script.notify
+            data:
               tell: >
                 {{ states('input_text.notifications_user2_name') | lower }}
               type: app_notification

--- a/Garden Irrigation/irrigation_remote_control.yaml
+++ b/Garden Irrigation/irrigation_remote_control.yaml
@@ -116,16 +116,16 @@ automation:
     id: irrigation_remote_control_switch
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_boolean.irrigation_remote_control
 
     action:
-      - service: >
+      - action: >
           automation.turn_{{ states('input_boolean.irrigation_remote_control') }}
-        data_template:
+        data:
           entity_id: >
             {% for automation in states.automation if automation.object_id.startswith('irrigation_remote_control')  and
                                                       automation.object_id != 'irrigation_remote_control_switch'%}
@@ -139,7 +139,7 @@ automation:
   - alias: Irrigation Remote Control Cancel
     id: irrigation_remote_control_cancel
     trigger:
-      - platform: state
+      - trigger: state
         entity_id: sensor.irrigation_remote_control
         to: Button_AB
 
@@ -153,7 +153,7 @@ automation:
 
     action:
       #=== Stop Cycle 3
-      - service: script.irrigation_cancel_irrigation
+      - action: script.irrigation_cancel_irrigation
         data:
           cycle: cycle3
           zone: >
@@ -164,19 +164,19 @@ automation:
             {% endfor %}
 
       #=== Restore previous settings
-      - service: scene.turn_on
+      - action: scene.turn_on
         data:
           entity_id: scene.irrigation_cycle3
 
 
       #=== Write To Log
-      - service: script.irrigation_remote_write_to_log
+      - action: script.irrigation_remote_write_to_log
         data:
           log_event: REMOTE_CANCEL
           reason: Button AB pressed (Cancel Irrigation)
 
       #=== Announce
-      - service: script.announcement
+      - action: script.announcement
         data:
           initiated_by: >
             {{ this.entity_id }}
@@ -193,7 +193,7 @@ automation:
     id: irrigation_remote_control_queued_notification
     mode: queued
     trigger:
-      - platform: state
+      - trigger: state
         entity_id: sensor.irrigation_remote_control
         to: 
           - 'Button_A'
@@ -214,8 +214,8 @@ automation:
         above: 0
 
     action:
-      - service: script.announcement
-        data_template:
+      - action: script.announcement
+        data:
           initiated_by: >
             {{ this.entity_id }}
           media_players:
@@ -251,7 +251,7 @@ automation:
     id: irrigation_remote_control_button_pressed
     mode: queued
     trigger:
-      - platform: state
+      - trigger: state
         entity_id: sensor.irrigation_remote_control
         to: 
           - 'Button_A'
@@ -288,14 +288,14 @@ automation:
 
     action:
         #=== Write To Log
-        - service: script.irrigation_remote_write_to_log
+        - action: script.irrigation_remote_write_to_log
           data:
             log_event: REMOTE_BUTTON_PRESS
             button: >
               {{ trigger.to_state.state }}
 
         #=== Save current settings
-        - service: scene.create
+        - action: scene.create
           data:
             scene_id: irrigation_cycle3
             snapshot_entities:
@@ -311,7 +311,7 @@ automation:
               - input_number.irrigation_cycle3_zone8_duration
 
         #=== Disable schedules for Cycles 1 and 2
-        - service: input_boolean.turn_off
+        - action: input_boolean.turn_off
           entity_id:
             - input_boolean.irrigation_cycle1_schedule_enabled
             - input_boolean.irrigation_cycle2_schedule_enabled
@@ -331,7 +331,7 @@ automation:
                       entity_id: input_boolean.irrigation_cycle3_running
                       state: 'on'
               sequence:
-                - service: script.announcement
+                - action: script.announcement
                   data:
                     initiated_by: >
                       {{ this.entity_id }}
@@ -350,8 +350,8 @@ automation:
                       {{ states('input_number.irrigation_number_of_zones') | int == repeat.index }}
 
                 sequence:
-                  - service: input_number.set_value
-                    data_template:
+                  - action: input_number.set_value
+                    data:
                       entity_id: >
                         {% set zoneindex = 'zone' ~ repeat.index | string %}
                         {{ 'input_number.irrigation_cycle3_' ~ zoneindex ~ '_duration' }}
@@ -372,10 +372,10 @@ automation:
 
                   sequence:
                     #=== Set all Lawn zones (1-4)
-                    - service: script.irrigation_remote_set_all_lawn_zones
+                    - action: script.irrigation_remote_set_all_lawn_zones
 
                     #=== Run Cycle 3
-                    - service: script.irrigation_remote_control_run_cycle
+                    - action: script.irrigation_remote_control_run_cycle
                       data:
                         message: >
                           {% if states('input_number.irrigation_remote_control_zone1_duration') ==
@@ -401,14 +401,14 @@ automation:
 
                   sequence:
                     #=== Set Zone 5 duration
-                    - service: input_number.set_value
+                    - action: input_number.set_value
                       data:
                         entity_id: input_number.irrigation_cycle3_zone5_duration
                         value: >
                           {{ states('input_number.irrigation_remote_control_zone5_duration') }}
 
                     #=== Run Cycle 3
-                    - service: script.irrigation_remote_control_run_cycle
+                    - action: script.irrigation_remote_control_run_cycle
                       data:
                         message: >
                           {% set duration = states('input_number.irrigation_remote_control_zone5_duration') | int %}
@@ -424,14 +424,14 @@ automation:
 
                   sequence:
                     #=== Set Zone 6 duration
-                    - service: input_number.set_value
+                    - action: input_number.set_value
                       data:
                         entity_id: input_number.irrigation_cycle3_zone6_duration
                         value: >
                           {{ states('input_number.irrigation_remote_control_zone6_duration') }}
 
                     #=== Run Cycle 3
-                    - service: script.irrigation_remote_control_run_cycle
+                    - action: script.irrigation_remote_control_run_cycle
                       data:
                         message: >
                           {% set duration = states('input_number.irrigation_remote_control_zone6_duration') | int %}
@@ -447,14 +447,14 @@ automation:
 
                   sequence:
                     #=== Set Zone 7 duration
-                    - service: input_number.set_value
+                    - action: input_number.set_value
                       data:
                         entity_id: input_number.irrigation_cycle3_zone7_duration
                         value: >
                           {{ states('input_number.irrigation_remote_control_zone7_duration') }}
 
                     #=== Run Cycle 3
-                    - service: script.irrigation_remote_control_run_cycle
+                    - action: script.irrigation_remote_control_run_cycle
                       data:
                         message: >
                           {% set duration = states('input_number.irrigation_remote_control_zone7_duration') | int %}
@@ -470,24 +470,24 @@ automation:
 
                   sequence:
                     #=== Set all Lawn zones (1-4)
-                    - service: script.irrigation_remote_set_all_lawn_zones
+                    - action: script.irrigation_remote_set_all_lawn_zones
 
                     #=== Set Zone 5 duration
-                    - service: input_number.set_value
+                    - action: input_number.set_value
                       data:
                         entity_id: input_number.irrigation_cycle3_zone5_duration
                         value: >
                           {{ states('input_number.irrigation_remote_control_zone5_duration') }}
 
                     #=== Set Zone 6 duration
-                    - service: input_number.set_value
+                    - action: input_number.set_value
                       data:
                         entity_id: input_number.irrigation_cycle3_zone6_duration
                         value: >
                           {{ states('input_number.irrigation_remote_control_zone6_duration') }}
 
                     #=== Run Cycle 3
-                    - service: script.irrigation_remote_control_run_cycle
+                    - action: script.irrigation_remote_control_run_cycle
                       data:
                         message: >
                           {% set duration = states('input_number.irrigation_remote_control_zone1_duration') | int +
@@ -507,21 +507,21 @@ automation:
 
                   sequence:
                     #=== Set Zone 5 duration
-                    - service: input_number.set_value
+                    - action: input_number.set_value
                       data:
                         entity_id: input_number.irrigation_cycle3_zone5_duration
                         value: >
                           {{ states('input_number.irrigation_remote_control_zone5_duration') }}
 
                     #=== Set Zone 6 duration
-                    - service: input_number.set_value
+                    - action: input_number.set_value
                       data:
                         entity_id: input_number.irrigation_cycle3_zone6_duration
                         value: >
                           {{ states('input_number.irrigation_remote_control_zone6_duration') }}
 
                     #=== Run Cycle 3
-                    - service: script.irrigation_remote_control_run_cycle
+                    - action: script.irrigation_remote_control_run_cycle
                       data:
                         message: >
                           {% set duration = states('input_number.irrigation_remote_control_zone5_duration') | int +
@@ -537,31 +537,31 @@ automation:
 
                   sequence:
                     #=== Set all Lawn zones (1-4)
-                    - service: script.irrigation_remote_set_all_lawn_zones
+                    - action: script.irrigation_remote_set_all_lawn_zones
 
                     #=== Set Zone 5 duration
-                    - service: input_number.set_value
+                    - action: input_number.set_value
                       data:
                         entity_id: input_number.irrigation_cycle3_zone5_duration
                         value: >
                           {{ states('input_number.irrigation_remote_control_zone5_duration') }}
 
                     #=== Set Zone 6 duration
-                    - service: input_number.set_value
+                    - action: input_number.set_value
                       data:
                         entity_id: input_number.irrigation_cycle3_zone6_duration
                         value: >
                           {{ states('input_number.irrigation_remote_control_zone6_duration') }}
 
                     #=== Set Zone 7 duration
-                    - service: input_number.set_value
+                    - action: input_number.set_value
                       data:
                         entity_id: input_number.irrigation_cycle3_zone7_duration
                         value: >
                           {{ states('input_number.irrigation_remote_control_zone7_duration') }}
 
                     #=== Run Cycle 3
-                    - service: script.irrigation_remote_control_run_cycle
+                    - action: script.irrigation_remote_control_run_cycle
                       data:
                         message: > 
                           {% set duration = states('input_number.irrigation_remote_control_zone1_duration') | int +
@@ -583,7 +583,7 @@ automation:
 
                   sequence:
                     #=== Set Zones 1 to 4 to 1 minute
-                    - service: input_number.set_value
+                    - action: input_number.set_value
                       data:
                         entity_id: 
                           - input_number.irrigation_cycle3_zone1_duration
@@ -593,7 +593,7 @@ automation:
                         value: 1
 
                     #=== Run Cycle 3
-                    - service: script.irrigation_remote_control_run_cycle
+                    - action: script.irrigation_remote_control_run_cycle
                       data:
                         message: > 
                           {% set duration = states('input_number.irrigation_remote_control_zone1_duration') | int +
@@ -623,7 +623,7 @@ script:
                 entity_id: input_boolean.irrigation_disable_switches
                 state: 'on'
             sequence:
-              - service: script.announcement
+              - action: script.announcement
                 data:
                   initiated_by: >
                     {{ this.entity_id }}
@@ -634,7 +634,7 @@ script:
                   announcement:
                     - tts: Warning! The irrigation switches are disabled.
 
-      - service: script.announcement
+      - action: script.announcement
         data:
           initiated_by: >
             {{ this.entity_id }}
@@ -647,11 +647,11 @@ script:
                 {{ message }}
 
       #=== Start Cycle 3
-      - service: input_boolean.turn_on
+      - action: input_boolean.turn_on
         entity_id: input_boolean.irrigation_cycle3_running
 
       #=== Write To Log
-      - service: script.irrigation_write_to_log
+      - action: script.irrigation_write_to_log
         data:
           log_event: CYCLE_STARTING
           cycle: 3
@@ -667,7 +667,7 @@ script:
           {{ is_state('input_boolean.irrigation_cycle3_running', 'off') }}
 
       #=== Restore previous settings
-      - service: scene.turn_on
+      - action: scene.turn_on
         data:
           entity_id: scene.irrigation_cycle3
 
@@ -683,28 +683,28 @@ script:
     alias: Irrigation Remote Set All Lawn Zones
     sequence:
       #=== Set Zone 1 duration
-      - service: input_number.set_value
+      - action: input_number.set_value
         data:
           entity_id: input_number.irrigation_cycle3_zone1_duration
           value: >
             {{ states('input_number.irrigation_remote_control_zone1_duration') }}
 
       #=== Set Zone 2 duration
-      - service: input_number.set_value
+      - action: input_number.set_value
         data:
           entity_id: input_number.irrigation_cycle3_zone2_duration
           value: >
             {{ states('input_number.irrigation_remote_control_zone2_duration') }}
 
       #=== Set Zone 3 duration
-      - service: input_number.set_value
+      - action: input_number.set_value
         data:
           entity_id: input_number.irrigation_cycle3_zone3_duration
           value: >
             {{ states('input_number.irrigation_remote_control_zone3_duration') }}
 
       #=== Set Zone 4 duration
-      - service: input_number.set_value
+      - action: input_number.set_value
         data:
           entity_id: input_number.irrigation_cycle3_zone4_duration
           value: >

--- a/Garden Irrigation/irrigation_run_a_cycle.yaml
+++ b/Garden Irrigation/irrigation_run_a_cycle.yaml
@@ -32,13 +32,13 @@ script:
 
           sequence:
             #=== Write To Log
-            - service: script.irrigation_write_to_log
+            - action: script.irrigation_write_to_log
               data:
                 log_event: ZONE_STARTING
                 zone: >
                   {{ repeat.index }}
                 seconds: >
-                  {{ states('sensor.irrigation_' ~ cycle ~ '_zone' ~ repeat.index ~ '_actual_duration_in_seconds') | int }}
+                  {{ states('sensor.irrigation_' ~ cycle ~ '_zone' ~ repeat.index ~ '_actual_duration_in_seconds') | int(0) }}
                 event_time: >
                   {{ now() }}
 
@@ -47,18 +47,18 @@ script:
                 - conditions:
                     condition: template
                     value_template: >
-                      {{ states('sensor.irrigation_' ~ cycle ~ '_zone' ~ repeat.index ~ '_actual_duration_in_seconds') | int != 0 }}
+                      {{ states('sensor.irrigation_' ~ cycle ~ '_zone' ~ repeat.index ~ '_actual_duration_in_seconds') | int(0) != 0 }}
 
                   sequence:
                     #=== Set FAILSAFE time to 10 seconds longer than the zone runtime
-                    - service: input_number.set_value
-                      data_template:        
+                    - action: input_number.set_value
+                      data:
                         entity_id: input_number.irrigation_failsafe_time_in_seconds
                         value: >
-                          {{ states('sensor.irrigation_' ~ cycle ~ '_zone' ~ repeat.index ~ '_actual_duration_in_seconds') | int + 10 }}
+                          {{ states('sensor.irrigation_' ~ cycle ~ '_zone' ~ repeat.index ~ '_actual_duration_in_seconds') | int(0) + 10 }}
 
                     #=== Write To Log
-                    - service: script.irrigation_write_to_log
+                    - action: script.irrigation_write_to_log
                       data:
                         log_event: FAILSAFE_SET
                         zone: >
@@ -67,14 +67,14 @@ script:
                           {{ now() }}
 
                     #=== Update Status with Zone being watered
-                    - service: input_text.set_value
-                      data_template:
+                    - action: input_text.set_value
+                      data:
                         entity_id: input_text.irrigation_current_status
                         value: Watering...
 
                     #=== Update last run details for this zone
-                    - service: input_text.set_value
-                      data_template:
+                    - action: input_text.set_value
+                      data:
                         entity_id: >
                           input_text.irrigation_zone{{ repeat.index }}_previous_duration_in_seconds
                         value: >
@@ -94,7 +94,7 @@ script:
       
                           sequence:
                             #=== Update Status
-                            - service: input_text.set_value
+                            - action: input_text.set_value
                               data:
                                 entity_id: input_text.irrigation_current_status
                                 value: Waiting for offline controller...
@@ -105,15 +105,15 @@ script:
                                   {{ states('input_number.irrigation_controller_offline_wait') | int }}
 
                     #=== Start the timer
-                    - service: timer.start
-                      data_template:
+                    - action: timer.start
+                      data:
                         entity_id: >
                           timer.irrigation_zone{{ repeat.index }}_timer
                         duration: >
-                          {{ states('sensor.irrigation_' ~ cycle ~ '_zone' ~ repeat.index ~ '_actual_duration_in_seconds') | int }}
+                          {{ states('sensor.irrigation_' ~ cycle ~ '_zone' ~ repeat.index ~ '_actual_duration_in_seconds') | int(0) }}
 
                     #=== Write To Log
-                    - service: script.irrigation_write_to_log
+                    - action: script.irrigation_write_to_log
                       data:
                         log_event: ZONE_WATERING
                         zone: >
@@ -135,8 +135,8 @@ script:
 
                         sequence:
                           #=== Start watering
-                          - service: switch.turn_on
-                            data_template:
+                          - action: switch.turn_on
+                            data:
                               entity_id: >
                                 {{ states('input_text.irrigation_zone' ~ repeat.index ~ '_switch_entity_id') }}
 
@@ -155,13 +155,13 @@ script:
                         {{ is_state(entity_id, 'idle') }}
 
                     #=== Stop Watering
-                    - service: switch.turn_off
-                      data_template:
+                    - action: switch.turn_off
+                      data:
                         entity_id: >
                           {{ states('input_text.irrigation_zone' ~ repeat.index ~ '_switch_entity_id') }}
 
                     #=== Write To Log
-                    - service: script.irrigation_write_to_log
+                    - action: script.irrigation_write_to_log
                       data:
                         log_event: ZONE_STOPPING
                         zone: >
@@ -170,8 +170,8 @@ script:
                           {{ now() }}
 
                     #=== Update last run time for this zone
-                    - service: input_text.set_value
-                      data_template:
+                    - action: input_text.set_value
+                      data:
                         entity_id: >
                           input_text.irrigation_zone{{ repeat.index }}_previous_duration_in_seconds
                         value: >
@@ -187,18 +187,18 @@ script:
                           {% endif %}
 
                     #=== Update last run total watering time
-                    - service: input_text.set_value
-                      data_template:
+                    - action: input_text.set_value
+                      data:
                         entity_id: >
                           input_text.irrigation_previous_total_watering_time
                         value: >
-                          {% set duration = states('sensor.irrigation_' ~ cycle ~ '_zone' ~ repeat.index ~ '_actual_duration_in_seconds') | int %}
-                          {% set current_total = states('input_text.irrigation_previous_total_watering_time') | float %}
+                          {% set duration = states('sensor.irrigation_' ~ cycle ~ '_zone' ~ repeat.index ~ '_actual_duration_in_seconds') | int(0) %}
+                          {% set current_total = states('input_text.irrigation_previous_total_watering_time') | float(0) %}
 
                           {{ (current_total + duration) | string }}
 
                     #=== Update Status
-                    - service: input_text.set_value
+                    - action: input_text.set_value
                       data:
                         entity_id: input_text.irrigation_current_status
                         value: Changing Zone...
@@ -209,8 +209,8 @@ script:
                             {{ states('input_number.irrigation_pause_between_zones_in_seconds') | int }}
 
       #=== CYCLE END PROCESSING
-      - service: input_boolean.turn_off
-        data_template:
+      - action: input_boolean.turn_off
+        data:
           entity_id: >
             input_boolean.irrigation_{{ cycle }}_running
 
@@ -221,20 +221,20 @@ script:
               value_template: >
                 {{ is_state('input_boolean.irrigation_' + cycle + '_schedule_today_only', 'on') }}
             sequence:
-              - service: homeassistant.turn_off
+              - action: homeassistant.turn_off
                 data:
                   entity_id:
                     - input_boolean.irrigation_{{ cycle }}_schedule_today_only
                     - input_boolean.irrigation_{{ cycle }}_schedule_enabled
 
       #=== Update Status to Idle
-      - service: input_text.set_value
+      - action: input_text.set_value
         data:
           entity_id: input_text.irrigation_current_status
           value: SYSTEM IDLE
 
       #=== Write To Log
-      - service: script.irrigation_write_to_log
+      - action: script.irrigation_write_to_log
         data:
           log_event: CYCLE_ENDED
           cycle: >

--- a/Garden Irrigation/irrigation_run_a_single_zone.yaml
+++ b/Garden Irrigation/irrigation_run_a_single_zone.yaml
@@ -38,7 +38,7 @@ script:
         state: 'off'
 
       #=== Save current settings
-      - service: scene.create
+      - action: scene.create
         data:
           scene_id: irrigation_cycle3
           snapshot_entities:
@@ -62,7 +62,7 @@ script:
             - input_number.irrigation_cycle3_zone16_duration
 
       #=== Disable schedules for Cycles 1 and 2
-      - service: input_boolean.turn_off
+      - action: input_boolean.turn_off
         entity_id:
           - input_boolean.irrigation_cycle1_schedule_enabled
           - input_boolean.irrigation_cycle2_schedule_enabled
@@ -74,8 +74,8 @@ script:
                 {{ states('input_number.irrigation_number_of_zones') | int == repeat.index }}
 
           sequence:
-            - service: input_number.set_value
-              data_template:
+            - action: input_number.set_value
+              data:
                 entity_id: >
                   {% set zoneindex = 'zone' ~ repeat.index | string %}
                   {% if zone != zoneindex %}
@@ -87,7 +87,7 @@ script:
 
 
       #=== Write To Log
-      - service: script.irrigation_write_to_log
+      - action: script.irrigation_write_to_log
         data:
           log_event: SINGLE_ZONE_STARTING
           zone: >
@@ -96,7 +96,7 @@ script:
             {{ now() }}
 
       #=== Start Cycle 3
-      - service: input_boolean.turn_on
+      - action: input_boolean.turn_on
         entity_id: input_boolean.irrigation_cycle3_running
 
       #=== Wait for Cycle 3 to start
@@ -108,6 +108,6 @@ script:
           {{ is_state('input_boolean.irrigation_cycle3_running', 'off') }}
 
       #=== Restore previous settings
-      - service: scene.turn_on
+      - action: scene.turn_on
         data:
           entity_id: scene.irrigation_cycle3

--- a/Garden Irrigation/irrigation_triggered.yaml
+++ b/Garden Irrigation/irrigation_triggered.yaml
@@ -16,17 +16,17 @@ automation:
     #==============
     trigger:
       #=== Cycle 1 Start Time
-      - platform: time
+      - trigger: time
         at: input_datetime.irrigation_cycle1_start_time
         id: cycle1
 
       #=== Cycle 2 Start Time
-      - platform: time
+      - trigger: time
         at: input_datetime.irrigation_cycle2_start_time
         id: cycle2
 
       #=== Cycle 3 Manual Run
-      - platform: state
+      - trigger: state
         entity_id: input_boolean.irrigation_cycle3_running
         to: 'on'
         id: cycle3
@@ -109,7 +109,7 @@ automation:
                 {{ states('input_text.irrigation_' ~ trigger.id ~ '_wait_for_entity_state') }}
 
           #=== Write To Log
-          - service: script.irrigation_write_to_log
+          - action: script.irrigation_write_to_log
             data:
               log_event: CYCLE_WAITING_FOR_ENTITY
               cycle: >
@@ -132,7 +132,7 @@ automation:
               {{ states('input_number.irrigation_' ~ trigger.id ~ '_wait_for_entity_name_timeout_duration') }}
 
           #=== Write To Log
-          - service: script.irrigation_write_to_log
+          - action: script.irrigation_write_to_log
             data:
               log_event: CYCLE_WAITING_FOR_ENTITY_COMPLETE
               cycle: >
@@ -150,7 +150,7 @@ automation:
                   {{ not wait.completed and timeout_continue == 'off' }}
             then:
               #=== Write To Log
-              - service: script.irrigation_write_to_log
+              - action: script.irrigation_write_to_log
                 data:
                   log_event: CYCLE_ABORTED_WAITING_FOR_ENTITY
                   cycle: >
@@ -159,8 +159,8 @@ automation:
                     {{ now() }}
 
               #=== Notify
-              - service: script.notify
-                data_template:
+              - action: script.notify
+                data:
                   show: true
                   tell: >
                     {{ states('input_text.notifications_user1_name') | lower }}
@@ -191,7 +191,7 @@ automation:
                      states(wait_for_entity_name) not in wait_for_entity_state }}
             then:
               #=== Write To Log
-              - service: script.irrigation_write_to_log
+              - action: script.irrigation_write_to_log
                 data:
                   log_event: CYCLE_CONTINUES_UNEXPECTED_STATE
                   cycle: >
@@ -200,8 +200,8 @@ automation:
                     {{ now() }}
 
               #=== Notify
-              - service: script.notify
-                data_template:
+              - action: script.notify
+                data:
                   show: true
                   tell: >
                     {{ states('input_text.notifications_user1_name') | lower }}
@@ -222,13 +222,13 @@ automation:
 
 
       #== Set the cycle to be running
-      - service: homeassistant.turn_on
+      - action: homeassistant.turn_on
         data:
           entity_id: >
             input_boolean.irrigation_{{ trigger.id }}_running
 
       #=== Write To Log
-      - service: script.irrigation_write_to_log
+      - action: script.irrigation_write_to_log
         data:
           log_event: CYCLE_STARTING
           cycle: >

--- a/Garden Irrigation/irrigation_triggered_cycle_start.yaml
+++ b/Garden Irrigation/irrigation_triggered_cycle_start.yaml
@@ -10,22 +10,22 @@ automation:
   - alias: Irrigation Triggered Cycle Start
     id: irrigation_triggered_cycle_start
     trigger:
-      - platform: state
+      - trigger: state
         entity_id: input_boolean.irrigation_cycle1_running
         to: 'on'
         
-      - platform: state
+      - trigger: state
         entity_id: input_boolean.irrigation_cycle2_running
         to: 'on'
 
-      - platform: state
+      - trigger: state
         entity_id: input_boolean.irrigation_cycle3_running
         to: 'on'
 
     action:
       #=== Set previous run times for all zones to ' '
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: >
             {% for input_text in states.input_text if input_text.object_id.startswith('irrigation_zone') and
                                                       input_text.object_id.endswith('_previous_duration_in_seconds')  -%}
@@ -35,20 +35,20 @@ automation:
           value: ''
       
       #=== Set previous total watering time to 'none'
-      - service: input_text.set_value
+      - action: input_text.set_value
         data:
           entity_id: input_text.irrigation_previous_total_watering_time
           value: None
 
       #=== Set previous cycle total time to zero
-      - service: input_text.set_value
+      - action: input_text.set_value
         data:
           entity_id: input_text.irrigation_previous_total_watering_time
           value: 0
 
       #=== Update Last Run cycle name
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_previous_run_cycle_name
           value: >
             {% if 'cycle1' in trigger.entity_id %}
@@ -60,22 +60,22 @@ automation:
             {% endif %}
 
       #=== Update Last Run Date
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_previous_run_date
           value: >
             {{ now().strftime("%A %-d %B") }}
 
       #=== Update Last Run Time
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_previous_run_time
           value: >
             {{ now().strftime("%H:%M") }}
 
       #=== START THE PROCESS
-      - service: script.irrigation_run_a_cycle
-        data_template:
+      - action: script.irrigation_run_a_cycle
+        data:
           cycle: >
             {% if trigger.entity_id == 'input_boolean.irrigation_cycle1_running' %}
               cycle1

--- a/Garden Irrigation/irrigation_ui_control.yaml
+++ b/Garden Irrigation/irrigation_ui_control.yaml
@@ -44,7 +44,7 @@ automation:
     id: irrigation_ui_show_weather_adjust_settings
     mode: queued
     trigger:
-      - platform: state
+      - trigger: state
         entity_id: 
           - input_boolean.irrigation_cycle1_adjust_for_rainfall
           - input_boolean.irrigation_cycle2_adjust_for_rainfall
@@ -53,7 +53,7 @@ automation:
         to: 'on'
 
     action:
-      - service: input_select.select_option
+      - action: input_select.select_option
         data:
           entity_id: input_select.irrigation_settings
           option: >
@@ -72,7 +72,7 @@ automation:
     id: irrigation_ui_duration_synchronisation
     mode: queued
     trigger: 
-      - platform: state
+      - trigger: state
         entity_id:
           - input_number.irrigation_cycle1_zone1_duration
           - input_number.irrigation_cycle1_zone1_duration_box
@@ -175,8 +175,8 @@ automation:
 
     action:
       #=== Keep input_number slider and box synchronised
-      - service: input_number.set_value
-        data_template:
+      - action: input_number.set_value
+        data:
           entity_id: >
             {% set cycle = 'cycle' ~ trigger.entity_id.split('cycle')[1][0] %}
             {% set zone = 'zone' ~ trigger.entity_id.split('zone')[1][0] %}

--- a/Garden Irrigation/irrigation_ui_initialise.yaml
+++ b/Garden Irrigation/irrigation_ui_initialise.yaml
@@ -14,10 +14,10 @@ automation:
     id: irrigation_ui_set_default_font
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_text.irrigation_ui_font_family
         to: ''
 
@@ -33,7 +33,7 @@ automation:
           state: ''
 
     action:
-      - service: input_text.set_value
+      - action: input_text.set_value
         data:
           entity_id: input_text.irrigation_ui_font_family
           value: var(--primary-font-family)
@@ -46,7 +46,7 @@ automation:
     id: irrigation_ui_set_default_user_names
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
     action:
       - repeat:
@@ -57,8 +57,8 @@ automation:
                 {% set user = 'user' ~ repeat.index | string %}
                 {{ is_state('input_text.notifications_' ~ user ~ '_name', 'unknown') }}
             
-            - service: input_text.set_value
-              data_template:
+            - action: input_text.set_value
+              data:
                 entity_id: >
                   {% set user = 'user' ~ repeat.index | string %}
                   {{ 'input_text.notifications_' ~ user ~ '_name' }}
@@ -73,7 +73,7 @@ automation:
     id: irrigation_ui_set_default_current_status
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
     condition:
@@ -82,7 +82,7 @@ automation:
         state: 'unknown'
 
     action:
-      - service: input_text.set_value
+      - action: input_text.set_value
         data:
           entity_id: input_text.irrigation_current_status
           value: NOTHING SCHEDULED
@@ -95,7 +95,7 @@ automation:
     id: irrigation_ui_set_default_cycle_names
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
     action:
       - repeat:
@@ -106,8 +106,8 @@ automation:
                 {% set cycle = 'cycle' ~ repeat.index | string %}
                 {{ is_state('input_text.irrigation_' ~ cycle ~ '_name', 'unknown') }}
             
-            - service: input_text.set_value
-              data_template:
+            - action: input_text.set_value
+              data:
                 entity_id: >
                   {% set zone = 'cycle' ~ repeat.index | string %}
                   {{ 'input_text.irrigation_' ~ cycle ~ '_name' }}
@@ -126,7 +126,7 @@ automation:
     id: irrigation_ui_set_default_zone_names
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
     action:
@@ -138,8 +138,8 @@ automation:
                 {% set zone = 'zone' ~ repeat.index | string %}
                 {{ is_state('input_text.irrigation_' ~ zone ~ '_name', 'unknown') }}
             
-            - service: input_text.set_value
-              data_template:
+            - action: input_text.set_value
+              data:
                 entity_id: >
                   {% set zone = 'zone' ~ repeat.index | string %}
                   {{ 'input_text.irrigation_' ~ zone ~ '_name' }}
@@ -155,7 +155,7 @@ automation:
     id: irrigation_ui_set_default_switch_entity_ids
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
     action:
@@ -167,8 +167,8 @@ automation:
                 {% set zone = 'zone' ~ repeat.index | string %}
                 {{ is_state('input_text.irrigation_' ~ zone ~ '_switch_entity_id', 'unknown') }}
             
-            - service: input_text.set_value
-              data_template:
+            - action: input_text.set_value
+              data:
                 entity_id: >
                   {% set zone = 'zone' ~ repeat.index | string %}
                   {{ 'input_text.irrigation_' ~ zone ~ '_switch_entity_id' }}

--- a/Garden Irrigation/irrigation_warnings.yaml
+++ b/Garden Irrigation/irrigation_warnings.yaml
@@ -31,7 +31,7 @@ automation:
     mode: queued
 
     trigger:
-      - platform: template
+      - trigger: template
         value_template: >
           {{ states(states('input_text.irrigation_external_sensor_controller_wifi'))  == 'unavailable' }}
 
@@ -56,7 +56,7 @@ automation:
       #       {{ now().timestamp() }}
 
       #=== Write To Log
-      - service: script.turn_on
+      - action: script.turn_on
         entity_id: script.irrigation_write_to_log
         data:
           variables:
@@ -65,8 +65,8 @@ automation:
               {{ now() }}
 
       #=== Persistent Notification
-      - service: script.notify
-        data_template:
+      - action: script.notify
+        data:
           show: true
           title: ⚠️ Irrigation Warning ⚠️
           message: >
@@ -81,8 +81,8 @@ automation:
           entity_id: input_boolean.irrigation_notify_user1
           state: 'on'
         then:
-          - service: script.notify
-            data_template:
+          - action: script.notify
+            data:
               tell: >
                 {{ states('input_text.notifications_user1_name') }}
               type: app_notification
@@ -98,8 +98,8 @@ automation:
           entity_id: input_boolean.irrigation_notify_user2
           state: 'on'
         then:
-          - service: script.notify
-            data_template:
+          - action: script.notify
+            data:
               tell: >
                 {{ states('input_text.notifications_user1_name') }}
               type: app_notification
@@ -119,7 +119,7 @@ automation:
     mode: queued
 
     trigger:
-      - platform: template
+      - trigger: template
         value_template: >
           {{ states(states('input_text.irrigation_external_sensor_controller_wifi'))  != 'unavailable' }}
 
@@ -137,7 +137,7 @@ automation:
 
     action:
       #=== Write To Log
-      - service: script.turn_on
+      - action: script.turn_on
         entity_id: script.irrigation_write_to_log
         data:
           variables:
@@ -150,8 +150,8 @@ automation:
             #   {{ (as_timestamp(now()) - state_attr('input_datetime.irrigation_controller_time_became_unavailable', 'timestamp')) | round }}
 
       #=== Persistent Notification
-      - service: script.notify
-        data_template:
+      - action: script.notify
+        data:
           show: true
           title: ⚠️ Irrigation Warning ⚠️
           message: >

--- a/Garden Irrigation/irrigation_weather_rainfall.yaml
+++ b/Garden Irrigation/irrigation_weather_rainfall.yaml
@@ -10,10 +10,10 @@ automation:
     id: irrigation_set_default_rainfall_today_sensor
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_text.irrigation_external_sensor_rainfall_today
         to: ''
 
@@ -29,8 +29,8 @@ automation:
           state: ''
 
     action:
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_external_sensor_rainfall_today
           value: sensor.rain_gauge
 
@@ -42,10 +42,10 @@ automation:
     id: irrigation_set_default_rainfall_yesterday_sensor
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_text.irrigation_external_sensor_rainfall_yesterday
         to: ''
 
@@ -61,8 +61,8 @@ automation:
           state: ''
 
     action:
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_external_sensor_rainfall_yesterday
           value: sensor.rain_gauge_yesterday
 
@@ -74,10 +74,10 @@ automation:
     id: irrigation_set_default_rainfall_last_twenty_four_hours_sensor
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_text.irrigation_external_sensor_rainfall_last_twenty_four_hours
         to: ''
 
@@ -93,8 +93,8 @@ automation:
           state: ''
 
     action:
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_external_sensor_rainfall_last_twenty_four_hours
           value: sensor.rain_gauge_rainfall_last_twenty_four_hours
 
@@ -105,10 +105,10 @@ automation:
     id: irrigation_set_default_rainfall_between_24_and_48_hours_ago
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_text.irrigation_external_sensor_rainfall_between_24_and_48_hours_ago
         to: ''
 
@@ -124,8 +124,8 @@ automation:
           state: ''
 
     action:
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_external_sensor_rainfall_between_24_and_48_hours_ago
           value: sensor.rain_gauge_rainfall_between_24_and_48_hours_ago
 
@@ -136,10 +136,10 @@ automation:
     id: irrigation_set_default_rainfall_between_48_and_72_hours_ago
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_text.irrigation_external_sensor_rainfall_between_48_and_72_hours_ago
         to: ''
 
@@ -155,8 +155,8 @@ automation:
           state: ''
 
     action:
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_external_sensor_rainfall_between_48_and_72_hours_ago
           value: sensor.rain_gauge_rainfall_between_48_and_72_hours_ago
 
@@ -167,10 +167,10 @@ automation:
     id: irrigation_set_default_rainfall_between_72_and_96_hours_ago
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_text.irrigation_external_sensor_rainfall_between_72_and_96_hours_ago
         to: ''
 
@@ -186,8 +186,8 @@ automation:
           state: ''
 
     action:
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_external_sensor_rainfall_between_72_and_96_hours_ago
           value: sensor.rain_gauge_rainfall_between_72_and_96_hours_ago
 
@@ -198,10 +198,10 @@ automation:
     id: irrigation_set_default_rainfall_between_96_and_120_hours_ago
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_text.irrigation_external_sensor_rainfall_between_96_and_120_hours_ago
         to: ''
 
@@ -217,8 +217,8 @@ automation:
           state: ''
 
     action:
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_external_sensor_rainfall_between_96_and_120_hours_ago
           value: sensor.rain_gauge_rainfall_between_96_and_120_hours_ago
 
@@ -230,10 +230,10 @@ automation:
     id: irrigation_set_default_raining_now_sensor
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_text.irrigation_external_sensor_raining_now
         to: ''
 
@@ -249,8 +249,8 @@ automation:
           state: ''
 
     action:
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_external_sensor_raining_now
           value: binary_sensor.raining_now
 
@@ -262,10 +262,10 @@ automation:
     id: irrigation_set_default_forecast_rain_sensor
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_text.irrigation_external_sensor_forecast_rain
         to: ''
 
@@ -281,8 +281,8 @@ automation:
           state: ''
 
     action:
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_external_sensor_forecast_rain
           value: sensor.openweathermap_forecast_precipitation
 
@@ -294,11 +294,11 @@ automation:
     id: irrigation_initialise_rainfall_sensors
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
     action:
-      - service: homeassistant.update_entity
+      - action: homeassistant.update_entity
         data:
           entity_id: 
             - sensor.irrigation_sensor_rainfall_today
@@ -313,25 +313,25 @@ automation:
   - alias: Irrigation Rainfall Nightly Update
     id: irrigation_rainfall_nightly_update
     trigger: 
-      - platform: time
+      - trigger: time
         at: "23:59:00"
 
     action:
-      - service: input_number.set_value
+      - action: input_number.set_value
         entity_id: input_number.irrigation_rainfall_4
-        data_template:
+        data:
           value: >
             {{ states('input_number.irrigation_rainfall_3') }}
 
-      - service: input_number.set_value
+      - action: input_number.set_value
         entity_id: input_number.irrigation_rainfall_3
-        data_template:
+        data:
           value: >
             {{ states('input_number.irrigation_rainfall_2') }}
 
-      - service: input_number.set_value
+      - action: input_number.set_value
         entity_id: input_number.irrigation_rainfall_2
-        data_template:
+        data:
           value: >
             {{ states(states('input_text.irrigation_external_sensor_rainfall_yesterday')) | float }}
 
@@ -348,7 +348,7 @@ automation:
     id: irrigation_rainfall_calculate_multiplier
     mode: queued
     trigger:
-      - platform: state
+      - trigger: state
         entity_id:
           - input_boolean.irrigation_rainfall_use_rolling_values
           - input_number.irrigation_days_of_rainfall_history_used
@@ -369,28 +369,28 @@ automation:
           - sensor.irrigation_sensor_rainfall_between_96_and_120_hours_ago
 
     action:
-      - service: input_number.set_value
-        data_template:
+      - action: input_number.set_value
+        data:
           entity_id: input_number.irrigation_rainfall_multiplier
           value: >
             {% if states('input_boolean.irrigation_rainfall_use_rolling_values') == 'on' %}
-              {% set rain_0 = states('sensor.irrigation_sensor_rainfall_last_twenty_four_hours') | float %}
-              {% set rain_1 = states('sensor.irrigation_sensor_rainfall_between_24_and_48_hours_ago') | float %}
-              {% set rain_2 = states('sensor.irrigation_sensor_rainfall_between_48_and_72_hours_ago')  | float%}
-              {% set rain_3 = states('sensor.irrigation_sensor_rainfall_between_72_and_96_hours_ago')  | float%}
-              {% set rain_4 = states('sensor.irrigation_sensor_rainfall_between_96_and_120_hours_ago')  | float%}
+              {% set rain_0 = states('sensor.irrigation_sensor_rainfall_last_twenty_four_hours') | float(0) %}
+              {% set rain_1 = states('sensor.irrigation_sensor_rainfall_between_24_and_48_hours_ago') | float(0) %}
+              {% set rain_2 = states('sensor.irrigation_sensor_rainfall_between_48_and_72_hours_ago')  | float(0)%}
+              {% set rain_3 = states('sensor.irrigation_sensor_rainfall_between_72_and_96_hours_ago')  | float(0)%}
+              {% set rain_4 = states('sensor.irrigation_sensor_rainfall_between_96_and_120_hours_ago')  | float(0)%}
             {% else %}
-              {% set rain_0 = states('sensor.irrigation_sensor_rainfall_today') | float %}
-              {% set rain_1 = states('sensor.irrigation_sensor_rainfall_yesterday') | float %}
-              {% set rain_2 = states('input_number.irrigation_rainfall_2')  | float%}
-              {% set rain_3 = states('input_number.irrigation_rainfall_3')  | float%}
-              {% set rain_4 = states('input_number.irrigation_rainfall_4')  | float%}
+              {% set rain_0 = states('sensor.irrigation_sensor_rainfall_today') | float(0) %}
+              {% set rain_1 = states('sensor.irrigation_sensor_rainfall_yesterday') | float(0) %}
+              {% set rain_2 = states('input_number.irrigation_rainfall_2')  | float(0)%}
+              {% set rain_3 = states('input_number.irrigation_rainfall_3')  | float(0)%}
+              {% set rain_4 = states('input_number.irrigation_rainfall_4')  | float(0)%}
             {% endif %}
 
-            {% set percent_1 = states('input_number.irrigation_rainfall_percentage_1') | float / 100 %}
-            {% set percent_2 = states('input_number.irrigation_rainfall_percentage_2') | float / 100 %}
-            {% set percent_3 = states('input_number.irrigation_rainfall_percentage_3') | float / 100 %}
-            {% set percent_4 = states('input_number.irrigation_rainfall_percentage_4') | float / 100 %}
+            {% set percent_1 = states('input_number.irrigation_rainfall_percentage_1') | float(0) / 100 %}
+            {% set percent_2 = states('input_number.irrigation_rainfall_percentage_2') | float(0) / 100 %}
+            {% set percent_3 = states('input_number.irrigation_rainfall_percentage_3') | float(0) / 100 %}
+            {% set percent_4 = states('input_number.irrigation_rainfall_percentage_4') | float(0) / 100 %}
             
             {% set rain_1 = rain_1 * percent_1 %}
             {% set rain_2 = rain_2 * percent_2 %}

--- a/Garden Irrigation/irrigation_weather_temperature.yaml
+++ b/Garden Irrigation/irrigation_weather_temperature.yaml
@@ -10,10 +10,10 @@ automation:
     id: irrigation_set_default_forecast_high_temperature_sensor
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_text.irrigation_external_sensor_forecast_high_temp
         to: ''
 
@@ -29,8 +29,8 @@ automation:
           state: ''
 
     action:
-      - service: input_text.set_value
-        data_template:
+      - action: input_text.set_value
+        data:
           entity_id: input_text.irrigation_external_sensor_forecast_high_temp
           value:  sensor.openweathermap_forecast_temperature
 
@@ -42,10 +42,10 @@ automation:
     id: irrigation_set_default_current_temperature_sensor
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
-      - platform: state
+      - trigger: state
         entity_id: input_text.irrigation_external_sensor_current_temp
         to: ''
 
@@ -61,7 +61,7 @@ automation:
           state: ''
 
     action:
-      - service: input_text.set_value
+      - action: input_text.set_value
         data:
           entity_id: input_text.irrigation_external_sensor_current_temp
           value: sensor.openweathermap_temperature
@@ -74,11 +74,11 @@ automation:
     id: irrigation_initialise_temperature_sensors
     trigger:
       #=== If HA starts
-      - platform: homeassistant
+      - trigger: homeassistant
         event: start
 
     action:
-      - service: homeassistant.update_entity
+      - action: homeassistant.update_entity
         data:
           entity_id: 
             - sensor.irrigation_sensor_forecast_high_temp
@@ -91,7 +91,7 @@ automation:
   - alias: Irrigation Temperature Update Highest Actual Temp Today
     id: irrigation_temperature_update_highest_actual_temp_today
     trigger:
-      - platform: state
+      - trigger: state
         entity_id:
           - sensor.irrigation_sensor_current_temp
 
@@ -107,8 +107,8 @@ automation:
             False
           {% endif %}
     action:
-      - service: input_number.set_value
-        data_template:
+      - action: input_number.set_value
+        data:
           entity_id: input_number.irrigation_temperature_highest_actual_temp_today
           value: >
             {{ states('sensor.irrigation_sensor_current_temp') | float }}
@@ -120,7 +120,7 @@ automation:
   - alias: Irrigation Temperature Update Highest Forecast High Temp Today
     id: irrigation_temperature_update_highest_forecast_high_temp_today
     trigger:
-      - platform: state
+      - trigger: state
         entity_id:
           - sensor.irrigation_sensor_forecast_high_temp
 
@@ -137,8 +137,8 @@ automation:
           {% endif %}
 
     action:
-      - service: input_number.set_value
-        data_template:
+      - action: input_number.set_value
+        data:
           entity_id: input_number.irrigation_temperature_highest_forecast_high_temp_today
           value: >
             {{ states('sensor.irrigation_sensor_forecast_high_temp') | float }}
@@ -155,13 +155,13 @@ automation:
   - alias: Irrigation Temperature Nightly Update
     id: irrigation_temperature_nightly_update
     trigger: 
-      - platform: time
+      - trigger: time
         at: "00:00:01"
 
     action:
-      - service: input_number.set_value
+      - action: input_number.set_value
         entity_id: input_number.irrigation_high_temp_4
-        data_template:
+        data:
           value: >
             {{ states('input_number.irrigation_high_temp_3') }}
 
@@ -169,40 +169,40 @@ automation:
       - delay:
           seconds: 5
 
-      - service: input_number.set_value
+      - action: input_number.set_value
         entity_id: input_number.irrigation_high_temp_3
-        data_template:
+        data:
           value: >
             {{ states('input_number.irrigation_high_temp_2') }}
 
-      - service: input_number.set_value
+      - action: input_number.set_value
         entity_id: input_number.irrigation_high_temp_2
-        data_template:
+        data:
           value: >
             {{ states('input_number.irrigation_high_temp_1') }}
 
-      - service: input_number.set_value
+      - action: input_number.set_value
         entity_id: input_number.irrigation_high_temp_1
-        data_template:
+        data:
           value: >
             {{ states('input_number.irrigation_temperature_highest_actual_temp_today') }}
 
       #=== Reset Todays Highest Actual Temp
-      - service: input_number.set_value
+      - action: input_number.set_value
         entity_id: input_number.irrigation_temperature_highest_actual_temp_today
-        data_template:
+        data:
           value: >
             {{ states('sensor.irrigation_sensor_current_temp') }}
 
       #=== Reset Todays Highest Forecast High Temperature
-      - service: input_number.set_value
+      - action: input_number.set_value
         entity_id: input_number.irrigation_temperature_highest_forecast_high_temp_today
-        data_template:
+        data:
           value: >
             {{ states('sensor.irrigation_sensor_forecast_high_temp') }}
 
       #=== Update the temperature multiplier
-      - service: script.irrigation_temperature_calculate_multiplier
+      - action: script.irrigation_temperature_calculate_multiplier
 
 
   #=============================================================================
@@ -212,14 +212,14 @@ automation:
     id: irrigation_temperature_options_update_multiplier
     mode: queued
     trigger:
-      - platform: state
+      - trigger: state
         entity_id:
           - input_number.irrigation_days_of_temp_history_used
           - input_number.irrigation_temperature_baseline
           - input_select.irrigation_high_temp_options
 
     action:
-      - service: script.irrigation_temperature_calculate_multiplier
+      - action: script.irrigation_temperature_calculate_multiplier
 
 
 #============
@@ -244,23 +244,23 @@ script:
     alias: Irrigation Temperature Calculate Multiplier
     mode: queued
     sequence:
-      - service: input_number.set_value
-        data_template:
+      - action: input_number.set_value
+        data:
           entity_id: input_number.irrigation_temp_multiplier
           value: >
             {% if is_state('input_select.irrigation_high_temp_options', 'Use Forecast') %}
-              {% set temp_0 = states('input_number.irrigation_temperature_highest_forecast_high_temp_today') | float %}
+              {% set temp_0 = states('input_number.irrigation_temperature_highest_forecast_high_temp_today') | float(0) %}
             {% elif is_state('input_select.irrigation_high_temp_options', 'Use Actual') %}
-              {% set temp_0 = states('input_number.irrigation_temperature_highest_actual_temp_today') | float %}
+              {% set temp_0 = states('input_number.irrigation_temperature_highest_actual_temp_today') | float(0) %}
             {% else %}
-              {% set temps = [states('input_number.irrigation_temperature_highest_forecast_high_temp_today') | float,
-                              states('input_number.irrigation_temperature_highest_actual_temp_today') | float ] %}
+              {% set temps = [states('input_number.irrigation_temperature_highest_forecast_high_temp_today') | float(0),
+                              states('input_number.irrigation_temperature_highest_actual_temp_today') | float(0) ] %}
               {% set temp_0 = temps | max %}                
             {% endif %}
-            {% set temp_1 = states('input_number.irrigation_high_temp_1') | float %}
-            {% set temp_2 = states('input_number.irrigation_high_temp_2') | float %}
-            {% set temp_3 = states('input_number.irrigation_high_temp_3') | float %}
-            {% set temp_4 = states('input_number.irrigation_high_temp_4') | float %}
+            {% set temp_1 = states('input_number.irrigation_high_temp_1') | float(0) %}
+            {% set temp_2 = states('input_number.irrigation_high_temp_2') | float(0) %}
+            {% set temp_3 = states('input_number.irrigation_high_temp_3') | float(0) %}
+            {% set temp_4 = states('input_number.irrigation_high_temp_4') | float(0) %}
 
             {% set days_used = states('input_number.irrigation_days_of_temp_history_used') | int %}
             {% set baseline = states('input_number.irrigation_temperature_baseline') | int %}


### PR DESCRIPTION
- service: -> action: (186), data_template: -> data: (71), platform: -> trigger: (86) for trigger keys (history_stats and event_data service:reload preserved)
- Harden numeric reads: zone-duration | int -> | int(0) in run_a_cycle; weather multiplier templates | float -> | float(0) (avoids ValueError on unknown/missing values)
- create_groups: emit entity LISTS via selectattr instead of a comma string, so an empty match yields an empty group instead of raising "Entity ID '' is invalid"

Generic improvements only; no install-specific wiring.